### PR TITLE
disallowExtraProperties will apply to children.

### DIFF
--- a/lib/modelValidator.js
+++ b/lib/modelValidator.js
@@ -295,7 +295,7 @@ function validateSpec(name, target, model, models, disallowExtraProperties, cust
             var value = target[key];
 
             if (value !== undefined) {
-                var valueErrors = validateValue(key, field, value, models);
+                var valueErrors = validateValue(key, field, value, models, disallowExtraProperties);
 
                 if (!valueErrors) {
                     valueErrors = validateCustom(model.id || name, key, value, customValidators);
@@ -373,10 +373,10 @@ function validateCustom(modelName, name, value, customValidators) {
     return errors.length > 0 ? errors : null;
 }
 
-function validateValue(key, field, value, models) {
+function validateValue(key, field, value, models, disallowExtraProperties) {
     var errors = [];
     if(value !== undefined) {
-        var typeErr = validateType(key, value, field, models);
+        var typeErr = validateType(key, value, field, models, disallowExtraProperties);
         if (typeErr) {
             if (typeErr.valid === undefined) {
                 errors.push(typeErr);
@@ -438,7 +438,7 @@ function validateValue(key, field, value, models) {
     return errors.length > 0 ? errors : null;
 }
 
-function validateType(name, property, field, models) {
+function validateType(name, property, field, models, disallowExtraProperties) {
 
     var expectedType = field.type;
     if(!expectedType) {
@@ -457,7 +457,7 @@ function validateType(name, property, field, models) {
     // asking any further questions of it.
     if(expectedType === 'object') {
         if(field.properties) {
-            return validate(name, property, field, models);
+            return validate(name, property, field, models, null, disallowExtraProperties);
         } else {
             return null;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-model-validator",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Validate incoming objects against Swagger Models.",
   "keywords": [
     "Swagger",

--- a/tests/extraPropertiesTests.js
+++ b/tests/extraPropertiesTests.js
@@ -49,5 +49,45 @@ module.exports.validatorTests = {
         test.ok(errors.errors[0].message === "Target property 'count' is not in the model", errors.errors[0].message);
 
         test.done();
+    },
+    disallowNestedExtraProperties: function (test) {
+        var person = {
+            id: 1,
+            names: {
+                firstName: "Bob",
+                lastName: "Roberts",
+                middleName: "Shouldn't be here"
+            }
+        };
+        var model = {
+            required: ['id'],
+            properties: {
+                id: {
+                    type: 'number',
+                    description: 'The object id'
+                },
+                names: {
+                    type: 'object',
+                    properties: {
+                        firstName: {
+                            type: "string",
+                            description: "First Name"
+                        },
+                        lastName: {
+                            type: "string",
+                            description: "Last Name"
+                        }
+                    }
+                }
+            }
+        };
+
+        var errors = validator.validate(person, model, null, false, true);
+
+        test.expect(2);
+        test.ok(!errors.valid);
+        test.ok(errors.errors[0].message === "Target property 'middleName' is not in the model", errors.errors[0].message);
+
+        test.done();
     }
 };


### PR DESCRIPTION
An object's children will now raise a validation error if they have properties that are not specified in the model and disallowExtraProperties is set to true.
